### PR TITLE
feat: use self as context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.0.10
+- Use `self` rather than `window` when accessing context.
+
 ## 0.0.9
 - Preparing for Dart 3
 

--- a/lib/bindings/accelerometer.dart
+++ b/lib/bindings/accelerometer.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library accelerometer;
 

--- a/lib/bindings/ambient_light.dart
+++ b/lib/bindings/ambient_light.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ambient_light;
 

--- a/lib/bindings/anchors.dart
+++ b/lib/bindings/anchors.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library anchors;
 

--- a/lib/bindings/angle_instanced_arrays.dart
+++ b/lib/bindings/angle_instanced_arrays.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library angle_instanced_arrays;
 

--- a/lib/bindings/attribution_reporting_api.dart
+++ b/lib/bindings/attribution_reporting_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library attribution_reporting_api;
 

--- a/lib/bindings/audio_output.dart
+++ b/lib/bindings/audio_output.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library audio_output;
 

--- a/lib/bindings/autoplay_detection.dart
+++ b/lib/bindings/autoplay_detection.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library autoplay_detection;
 

--- a/lib/bindings/background_fetch.dart
+++ b/lib/bindings/background_fetch.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library background_fetch;
 

--- a/lib/bindings/background_sync.dart
+++ b/lib/bindings/background_sync.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library background_sync;
 

--- a/lib/bindings/badging.dart
+++ b/lib/bindings/badging.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library badging;
 

--- a/lib/bindings/battery_status.dart
+++ b/lib/bindings/battery_status.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library battery_status;
 

--- a/lib/bindings/beacon.dart
+++ b/lib/bindings/beacon.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library beacon;
 

--- a/lib/bindings/capture_handle_identity.dart
+++ b/lib/bindings/capture_handle_identity.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library capture_handle_identity;
 

--- a/lib/bindings/clipboard_apis.dart
+++ b/lib/bindings/clipboard_apis.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library clipboard_apis;
 

--- a/lib/bindings/close_watcher.dart
+++ b/lib/bindings/close_watcher.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library close_watcher;
 

--- a/lib/bindings/compat.dart
+++ b/lib/bindings/compat.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library compat;
 

--- a/lib/bindings/compression.dart
+++ b/lib/bindings/compression.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library compression;
 

--- a/lib/bindings/compute_pressure.dart
+++ b/lib/bindings/compute_pressure.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library compute_pressure;
 

--- a/lib/bindings/console.dart
+++ b/lib/bindings/console.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library console;
 

--- a/lib/bindings/contact_picker_1.dart
+++ b/lib/bindings/contact_picker_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library contact_picker_1;
 

--- a/lib/bindings/content_index.dart
+++ b/lib/bindings/content_index.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library content_index;
 

--- a/lib/bindings/cookie_store.dart
+++ b/lib/bindings/cookie_store.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library cookie_store;
 

--- a/lib/bindings/crash_reporting.dart
+++ b/lib/bindings/crash_reporting.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library crash_reporting;
 

--- a/lib/bindings/credential_management_1.dart
+++ b/lib/bindings/credential_management_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library credential_management_1;
 

--- a/lib/bindings/csp3.dart
+++ b/lib/bindings/csp3.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library csp3;
 

--- a/lib/bindings/csp_embedded_enforcement.dart
+++ b/lib/bindings/csp_embedded_enforcement.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library csp_embedded_enforcement;
 

--- a/lib/bindings/csp_next.dart
+++ b/lib/bindings/csp_next.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library csp_next;
 

--- a/lib/bindings/css_animation_worklet_1.dart
+++ b/lib/bindings/css_animation_worklet_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_animation_worklet_1;
 

--- a/lib/bindings/css_animations_1.dart
+++ b/lib/bindings/css_animations_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_animations_1;
 

--- a/lib/bindings/css_animations_2.dart
+++ b/lib/bindings/css_animations_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_animations_2;
 

--- a/lib/bindings/css_cascade_5.dart
+++ b/lib/bindings/css_cascade_5.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_cascade_5;
 

--- a/lib/bindings/css_color_5.dart
+++ b/lib/bindings/css_color_5.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_color_5;
 

--- a/lib/bindings/css_conditional_3.dart
+++ b/lib/bindings/css_conditional_3.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_conditional_3;
 

--- a/lib/bindings/css_contain_2.dart
+++ b/lib/bindings/css_contain_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_contain_2;
 

--- a/lib/bindings/css_contain_3.dart
+++ b/lib/bindings/css_contain_3.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_contain_3;
 

--- a/lib/bindings/css_counter_styles_3.dart
+++ b/lib/bindings/css_counter_styles_3.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_counter_styles_3;
 

--- a/lib/bindings/css_font_loading_3.dart
+++ b/lib/bindings/css_font_loading_3.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_font_loading_3;
 

--- a/lib/bindings/css_fonts_4.dart
+++ b/lib/bindings/css_fonts_4.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_fonts_4;
 

--- a/lib/bindings/css_highlight_api_1.dart
+++ b/lib/bindings/css_highlight_api_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_highlight_api_1;
 

--- a/lib/bindings/css_images_4.dart
+++ b/lib/bindings/css_images_4.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_images_4;
 

--- a/lib/bindings/css_layout_api_1.dart
+++ b/lib/bindings/css_layout_api_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_layout_api_1;
 

--- a/lib/bindings/css_masking_1.dart
+++ b/lib/bindings/css_masking_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_masking_1;
 

--- a/lib/bindings/css_nav_1.dart
+++ b/lib/bindings/css_nav_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_nav_1;
 

--- a/lib/bindings/css_nesting_1.dart
+++ b/lib/bindings/css_nesting_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_nesting_1;
 

--- a/lib/bindings/css_paint_api_1.dart
+++ b/lib/bindings/css_paint_api_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_paint_api_1;
 

--- a/lib/bindings/css_parser_api.dart
+++ b/lib/bindings/css_parser_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_parser_api;
 

--- a/lib/bindings/css_properties_values_api_1.dart
+++ b/lib/bindings/css_properties_values_api_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_properties_values_api_1;
 

--- a/lib/bindings/css_pseudo_4.dart
+++ b/lib/bindings/css_pseudo_4.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_pseudo_4;
 

--- a/lib/bindings/css_regions_1.dart
+++ b/lib/bindings/css_regions_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_regions_1;
 

--- a/lib/bindings/css_shadow_parts_1.dart
+++ b/lib/bindings/css_shadow_parts_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_shadow_parts_1;
 

--- a/lib/bindings/css_transitions_1.dart
+++ b/lib/bindings/css_transitions_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_transitions_1;
 

--- a/lib/bindings/css_transitions_2.dart
+++ b/lib/bindings/css_transitions_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_transitions_2;
 

--- a/lib/bindings/css_typed_om_1.dart
+++ b/lib/bindings/css_typed_om_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_typed_om_1;
 

--- a/lib/bindings/css_view_transitions_1.dart
+++ b/lib/bindings/css_view_transitions_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library css_view_transitions_1;
 

--- a/lib/bindings/cssom_1.dart
+++ b/lib/bindings/cssom_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library cssom_1;
 

--- a/lib/bindings/cssom_view_1.dart
+++ b/lib/bindings/cssom_view_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library cssom_view_1;
 

--- a/lib/bindings/custom_state_pseudo_class.dart
+++ b/lib/bindings/custom_state_pseudo_class.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library custom_state_pseudo_class;
 

--- a/lib/bindings/datacue.dart
+++ b/lib/bindings/datacue.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library datacue;
 

--- a/lib/bindings/deprecation_reporting.dart
+++ b/lib/bindings/deprecation_reporting.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library deprecation_reporting;
 

--- a/lib/bindings/device_memory_1.dart
+++ b/lib/bindings/device_memory_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library device_memory_1;
 

--- a/lib/bindings/device_posture.dart
+++ b/lib/bindings/device_posture.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library device_posture;
 

--- a/lib/bindings/digital_goods.dart
+++ b/lib/bindings/digital_goods.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library digital_goods;
 

--- a/lib/bindings/dom.dart
+++ b/lib/bindings/dom.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library dom;
 

--- a/lib/bindings/dom_parsing.dart
+++ b/lib/bindings/dom_parsing.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library dom_parsing;
 

--- a/lib/bindings/edit_context.dart
+++ b/lib/bindings/edit_context.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library edit_context;
 

--- a/lib/bindings/element_timing.dart
+++ b/lib/bindings/element_timing.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library element_timing;
 

--- a/lib/bindings/encoding.dart
+++ b/lib/bindings/encoding.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library encoding;
 

--- a/lib/bindings/encrypted_media.dart
+++ b/lib/bindings/encrypted_media.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library encrypted_media;
 

--- a/lib/bindings/entries_api.dart
+++ b/lib/bindings/entries_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library entries_api;
 

--- a/lib/bindings/epub_rs_33.dart
+++ b/lib/bindings/epub_rs_33.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library epub_rs_33;
 

--- a/lib/bindings/event_timing.dart
+++ b/lib/bindings/event_timing.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library event_timing;
 

--- a/lib/bindings/ext_blend_minmax.dart
+++ b/lib/bindings/ext_blend_minmax.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_blend_minmax;
 

--- a/lib/bindings/ext_clip_cull_distance.dart
+++ b/lib/bindings/ext_clip_cull_distance.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_clip_cull_distance;
 

--- a/lib/bindings/ext_color_buffer_float.dart
+++ b/lib/bindings/ext_color_buffer_float.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_color_buffer_float;
 

--- a/lib/bindings/ext_color_buffer_half_float.dart
+++ b/lib/bindings/ext_color_buffer_half_float.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_color_buffer_half_float;
 

--- a/lib/bindings/ext_disjoint_timer_query.dart
+++ b/lib/bindings/ext_disjoint_timer_query.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_disjoint_timer_query;
 

--- a/lib/bindings/ext_disjoint_timer_query_webgl2.dart
+++ b/lib/bindings/ext_disjoint_timer_query_webgl2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_disjoint_timer_query_webgl2;
 

--- a/lib/bindings/ext_float_blend.dart
+++ b/lib/bindings/ext_float_blend.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_float_blend;
 

--- a/lib/bindings/ext_frag_depth.dart
+++ b/lib/bindings/ext_frag_depth.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_frag_depth;
 

--- a/lib/bindings/ext_shader_texture_lod.dart
+++ b/lib/bindings/ext_shader_texture_lod.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_shader_texture_lod;
 

--- a/lib/bindings/ext_srgb.dart
+++ b/lib/bindings/ext_srgb.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_srgb;
 

--- a/lib/bindings/ext_texture_compression_bptc.dart
+++ b/lib/bindings/ext_texture_compression_bptc.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_texture_compression_bptc;
 

--- a/lib/bindings/ext_texture_compression_rgtc.dart
+++ b/lib/bindings/ext_texture_compression_rgtc.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_texture_compression_rgtc;
 

--- a/lib/bindings/ext_texture_filter_anisotropic.dart
+++ b/lib/bindings/ext_texture_filter_anisotropic.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_texture_filter_anisotropic;
 

--- a/lib/bindings/ext_texture_norm16.dart
+++ b/lib/bindings/ext_texture_norm16.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ext_texture_norm16;
 

--- a/lib/bindings/eyedropper_api.dart
+++ b/lib/bindings/eyedropper_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library eyedropper_api;
 

--- a/lib/bindings/fedcm.dart
+++ b/lib/bindings/fedcm.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library fedcm;
 

--- a/lib/bindings/fetch.dart
+++ b/lib/bindings/fetch.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library fetch;
 

--- a/lib/bindings/fido_v2_1.dart
+++ b/lib/bindings/fido_v2_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library fido_v2_1;
 

--- a/lib/bindings/file_system_access.dart
+++ b/lib/bindings/file_system_access.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library file_system_access;
 

--- a/lib/bindings/fileapi.dart
+++ b/lib/bindings/fileapi.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library fileapi;
 

--- a/lib/bindings/filter_effects_1.dart
+++ b/lib/bindings/filter_effects_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library filter_effects_1;
 

--- a/lib/bindings/font_metrics_api_1.dart
+++ b/lib/bindings/font_metrics_api_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library font_metrics_api_1;
 

--- a/lib/bindings/fs.dart
+++ b/lib/bindings/fs.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library fs;
 

--- a/lib/bindings/fullscreen.dart
+++ b/lib/bindings/fullscreen.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library fullscreen;
 

--- a/lib/bindings/gamepad.dart
+++ b/lib/bindings/gamepad.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library gamepad;
 

--- a/lib/bindings/gamepad_extensions.dart
+++ b/lib/bindings/gamepad_extensions.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library gamepad_extensions;
 

--- a/lib/bindings/generic_sensor.dart
+++ b/lib/bindings/generic_sensor.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library generic_sensor;
 

--- a/lib/bindings/geolocation.dart
+++ b/lib/bindings/geolocation.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library geolocation;
 

--- a/lib/bindings/geolocation_sensor.dart
+++ b/lib/bindings/geolocation_sensor.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library geolocation_sensor;
 

--- a/lib/bindings/geometry_1.dart
+++ b/lib/bindings/geometry_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library geometry_1;
 

--- a/lib/bindings/get_installed_related_apps.dart
+++ b/lib/bindings/get_installed_related_apps.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library get_installed_related_apps;
 

--- a/lib/bindings/gyroscope.dart
+++ b/lib/bindings/gyroscope.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library gyroscope;
 

--- a/lib/bindings/hr_time_3.dart
+++ b/lib/bindings/hr_time_3.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library hr_time_3;
 

--- a/lib/bindings/html.dart
+++ b/lib/bindings/html.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library html;
 

--- a/lib/bindings/html_media_capture.dart
+++ b/lib/bindings/html_media_capture.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library html_media_capture;
 

--- a/lib/bindings/idle_detection.dart
+++ b/lib/bindings/idle_detection.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library idle_detection;
 

--- a/lib/bindings/image_capture.dart
+++ b/lib/bindings/image_capture.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library image_capture;
 

--- a/lib/bindings/image_resource.dart
+++ b/lib/bindings/image_resource.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library image_resource;
 

--- a/lib/bindings/indexeddb_3.dart
+++ b/lib/bindings/indexeddb_3.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library indexeddb_3;
 

--- a/lib/bindings/ink_enhancement.dart
+++ b/lib/bindings/ink_enhancement.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ink_enhancement;
 

--- a/lib/bindings/input_device_capabilities.dart
+++ b/lib/bindings/input_device_capabilities.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library input_device_capabilities;
 

--- a/lib/bindings/input_events_2.dart
+++ b/lib/bindings/input_events_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library input_events_2;
 

--- a/lib/bindings/intersection_observer.dart
+++ b/lib/bindings/intersection_observer.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library intersection_observer;
 

--- a/lib/bindings/intervention_reporting.dart
+++ b/lib/bindings/intervention_reporting.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library intervention_reporting;
 

--- a/lib/bindings/is_input_pending.dart
+++ b/lib/bindings/is_input_pending.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library is_input_pending;
 

--- a/lib/bindings/js_self_profiling.dart
+++ b/lib/bindings/js_self_profiling.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library js_self_profiling;
 

--- a/lib/bindings/json_ld11_api.dart
+++ b/lib/bindings/json_ld11_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library json_ld11_api;
 

--- a/lib/bindings/json_ld11_framing.dart
+++ b/lib/bindings/json_ld11_framing.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library json_ld11_framing;
 

--- a/lib/bindings/keyboard_lock.dart
+++ b/lib/bindings/keyboard_lock.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library keyboard_lock;
 

--- a/lib/bindings/keyboard_map.dart
+++ b/lib/bindings/keyboard_map.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library keyboard_map;
 

--- a/lib/bindings/khr_parallel_shader_compile.dart
+++ b/lib/bindings/khr_parallel_shader_compile.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library khr_parallel_shader_compile;
 

--- a/lib/bindings/largest_contentful_paint.dart
+++ b/lib/bindings/largest_contentful_paint.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library largest_contentful_paint;
 

--- a/lib/bindings/layout_instability.dart
+++ b/lib/bindings/layout_instability.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library layout_instability;
 

--- a/lib/bindings/local_font_access.dart
+++ b/lib/bindings/local_font_access.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library local_font_access;
 

--- a/lib/bindings/longtasks_1.dart
+++ b/lib/bindings/longtasks_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library longtasks_1;
 

--- a/lib/bindings/magnetometer.dart
+++ b/lib/bindings/magnetometer.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library magnetometer;
 

--- a/lib/bindings/manifest_incubations.dart
+++ b/lib/bindings/manifest_incubations.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library manifest_incubations;
 

--- a/lib/bindings/mathml_core.dart
+++ b/lib/bindings/mathml_core.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mathml_core;
 

--- a/lib/bindings/media_capabilities.dart
+++ b/lib/bindings/media_capabilities.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library media_capabilities;
 

--- a/lib/bindings/media_playback_quality.dart
+++ b/lib/bindings/media_playback_quality.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library media_playback_quality;
 

--- a/lib/bindings/media_source_2.dart
+++ b/lib/bindings/media_source_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library media_source_2;
 

--- a/lib/bindings/mediacapture_automation.dart
+++ b/lib/bindings/mediacapture_automation.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mediacapture_automation;
 

--- a/lib/bindings/mediacapture_fromelement.dart
+++ b/lib/bindings/mediacapture_fromelement.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mediacapture_fromelement;
 

--- a/lib/bindings/mediacapture_handle_actions.dart
+++ b/lib/bindings/mediacapture_handle_actions.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mediacapture_handle_actions;
 

--- a/lib/bindings/mediacapture_region.dart
+++ b/lib/bindings/mediacapture_region.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mediacapture_region;
 

--- a/lib/bindings/mediacapture_streams.dart
+++ b/lib/bindings/mediacapture_streams.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mediacapture_streams;
 

--- a/lib/bindings/mediacapture_transform.dart
+++ b/lib/bindings/mediacapture_transform.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mediacapture_transform;
 

--- a/lib/bindings/mediacapture_viewport.dart
+++ b/lib/bindings/mediacapture_viewport.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mediacapture_viewport;
 

--- a/lib/bindings/mediasession.dart
+++ b/lib/bindings/mediasession.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mediasession;
 

--- a/lib/bindings/mediastream_recording.dart
+++ b/lib/bindings/mediastream_recording.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mediastream_recording;
 

--- a/lib/bindings/model_element.dart
+++ b/lib/bindings/model_element.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library model_element;
 

--- a/lib/bindings/mst_content_hint.dart
+++ b/lib/bindings/mst_content_hint.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library mst_content_hint;
 

--- a/lib/bindings/navigation_api.dart
+++ b/lib/bindings/navigation_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library navigation_api;
 

--- a/lib/bindings/navigation_timing_2.dart
+++ b/lib/bindings/navigation_timing_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library navigation_timing_2;
 

--- a/lib/bindings/netinfo.dart
+++ b/lib/bindings/netinfo.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library netinfo;
 

--- a/lib/bindings/notifications.dart
+++ b/lib/bindings/notifications.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library notifications;
 

--- a/lib/bindings/oes_draw_buffers_indexed.dart
+++ b/lib/bindings/oes_draw_buffers_indexed.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library oes_draw_buffers_indexed;
 

--- a/lib/bindings/oes_element_index_uint.dart
+++ b/lib/bindings/oes_element_index_uint.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library oes_element_index_uint;
 

--- a/lib/bindings/oes_fbo_render_mipmap.dart
+++ b/lib/bindings/oes_fbo_render_mipmap.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library oes_fbo_render_mipmap;
 

--- a/lib/bindings/oes_standard_derivatives.dart
+++ b/lib/bindings/oes_standard_derivatives.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library oes_standard_derivatives;
 

--- a/lib/bindings/oes_texture_float.dart
+++ b/lib/bindings/oes_texture_float.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library oes_texture_float;
 

--- a/lib/bindings/oes_texture_float_linear.dart
+++ b/lib/bindings/oes_texture_float_linear.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library oes_texture_float_linear;
 

--- a/lib/bindings/oes_texture_half_float.dart
+++ b/lib/bindings/oes_texture_half_float.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library oes_texture_half_float;
 

--- a/lib/bindings/oes_texture_half_float_linear.dart
+++ b/lib/bindings/oes_texture_half_float_linear.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library oes_texture_half_float_linear;
 

--- a/lib/bindings/oes_vertex_array_object.dart
+++ b/lib/bindings/oes_vertex_array_object.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library oes_vertex_array_object;
 

--- a/lib/bindings/orientation_event.dart
+++ b/lib/bindings/orientation_event.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library orientation_event;
 

--- a/lib/bindings/orientation_sensor.dart
+++ b/lib/bindings/orientation_sensor.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library orientation_sensor;
 

--- a/lib/bindings/ovr_multiview2.dart
+++ b/lib/bindings/ovr_multiview2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ovr_multiview2;
 

--- a/lib/bindings/page_lifecycle.dart
+++ b/lib/bindings/page_lifecycle.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library page_lifecycle;
 

--- a/lib/bindings/paint_timing.dart
+++ b/lib/bindings/paint_timing.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library paint_timing;
 

--- a/lib/bindings/payment_handler.dart
+++ b/lib/bindings/payment_handler.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library payment_handler;
 

--- a/lib/bindings/payment_request_1_1.dart
+++ b/lib/bindings/payment_request_1_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library payment_request_1_1;
 

--- a/lib/bindings/performance_measure_memory.dart
+++ b/lib/bindings/performance_measure_memory.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library performance_measure_memory;
 

--- a/lib/bindings/performance_timeline.dart
+++ b/lib/bindings/performance_timeline.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library performance_timeline;
 

--- a/lib/bindings/periodic_background_sync.dart
+++ b/lib/bindings/periodic_background_sync.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library periodic_background_sync;
 

--- a/lib/bindings/permissions.dart
+++ b/lib/bindings/permissions.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library permissions;
 

--- a/lib/bindings/permissions_policy_1.dart
+++ b/lib/bindings/permissions_policy_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library permissions_policy_1;
 

--- a/lib/bindings/permissions_request.dart
+++ b/lib/bindings/permissions_request.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library permissions_request;
 

--- a/lib/bindings/permissions_revoke.dart
+++ b/lib/bindings/permissions_revoke.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library permissions_revoke;
 

--- a/lib/bindings/picture_in_picture.dart
+++ b/lib/bindings/picture_in_picture.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library picture_in_picture;
 

--- a/lib/bindings/pointerevents3.dart
+++ b/lib/bindings/pointerevents3.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library pointerevents3;
 

--- a/lib/bindings/pointerlock_2.dart
+++ b/lib/bindings/pointerlock_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library pointerlock_2;
 

--- a/lib/bindings/portals.dart
+++ b/lib/bindings/portals.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library portals;
 

--- a/lib/bindings/prefer_current_tab.dart
+++ b/lib/bindings/prefer_current_tab.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library prefer_current_tab;
 

--- a/lib/bindings/prerendering_revamped.dart
+++ b/lib/bindings/prerendering_revamped.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library prerendering_revamped;
 

--- a/lib/bindings/presentation_api.dart
+++ b/lib/bindings/presentation_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library presentation_api;
 

--- a/lib/bindings/priority_hints.dart
+++ b/lib/bindings/priority_hints.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library priority_hints;
 

--- a/lib/bindings/private_click_measurement.dart
+++ b/lib/bindings/private_click_measurement.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library private_click_measurement;
 

--- a/lib/bindings/proximity.dart
+++ b/lib/bindings/proximity.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library proximity;
 

--- a/lib/bindings/push_api.dart
+++ b/lib/bindings/push_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library push_api;
 

--- a/lib/bindings/raw_camera_access.dart
+++ b/lib/bindings/raw_camera_access.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library raw_camera_access;
 

--- a/lib/bindings/referrer_policy.dart
+++ b/lib/bindings/referrer_policy.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library referrer_policy;
 

--- a/lib/bindings/remote_playback.dart
+++ b/lib/bindings/remote_playback.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library remote_playback;
 

--- a/lib/bindings/reporting_1.dart
+++ b/lib/bindings/reporting_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library reporting_1;
 

--- a/lib/bindings/requestidlecallback.dart
+++ b/lib/bindings/requestidlecallback.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library requestidlecallback;
 

--- a/lib/bindings/resize_observer_1.dart
+++ b/lib/bindings/resize_observer_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library resize_observer_1;
 

--- a/lib/bindings/resource_timing.dart
+++ b/lib/bindings/resource_timing.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library resource_timing;
 

--- a/lib/bindings/sanitizer_api.dart
+++ b/lib/bindings/sanitizer_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library sanitizer_api;
 

--- a/lib/bindings/savedata.dart
+++ b/lib/bindings/savedata.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library savedata;
 

--- a/lib/bindings/scheduling_apis.dart
+++ b/lib/bindings/scheduling_apis.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library scheduling_apis;
 

--- a/lib/bindings/screen_capture.dart
+++ b/lib/bindings/screen_capture.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library screen_capture;
 

--- a/lib/bindings/screen_orientation.dart
+++ b/lib/bindings/screen_orientation.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library screen_orientation;
 

--- a/lib/bindings/screen_wake_lock.dart
+++ b/lib/bindings/screen_wake_lock.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library screen_wake_lock;
 

--- a/lib/bindings/scroll_animations_1.dart
+++ b/lib/bindings/scroll_animations_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library scroll_animations_1;
 

--- a/lib/bindings/scroll_to_text_fragment.dart
+++ b/lib/bindings/scroll_to_text_fragment.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library scroll_to_text_fragment;
 

--- a/lib/bindings/secure_payment_confirmation.dart
+++ b/lib/bindings/secure_payment_confirmation.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library secure_payment_confirmation;
 

--- a/lib/bindings/selection_api.dart
+++ b/lib/bindings/selection_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library selection_api;
 

--- a/lib/bindings/serial.dart
+++ b/lib/bindings/serial.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library serial;
 

--- a/lib/bindings/server_timing.dart
+++ b/lib/bindings/server_timing.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library server_timing;
 

--- a/lib/bindings/service_workers.dart
+++ b/lib/bindings/service_workers.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library service_workers;
 

--- a/lib/bindings/shape_detection_api.dart
+++ b/lib/bindings/shape_detection_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library shape_detection_api;
 

--- a/lib/bindings/speech_api.dart
+++ b/lib/bindings/speech_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library speech_api;
 

--- a/lib/bindings/storage.dart
+++ b/lib/bindings/storage.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library storage;
 

--- a/lib/bindings/storage_access.dart
+++ b/lib/bindings/storage_access.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library storage_access;
 

--- a/lib/bindings/streams.dart
+++ b/lib/bindings/streams.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library streams;
 

--- a/lib/bindings/svg2.dart
+++ b/lib/bindings/svg2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library svg2;
 

--- a/lib/bindings/svg_animations.dart
+++ b/lib/bindings/svg_animations.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library svg_animations;
 

--- a/lib/bindings/testutils.dart
+++ b/lib/bindings/testutils.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library testutils;
 

--- a/lib/bindings/text_detection_api.dart
+++ b/lib/bindings/text_detection_api.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library text_detection_api;
 

--- a/lib/bindings/touch_events.dart
+++ b/lib/bindings/touch_events.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library touch_events;
 

--- a/lib/bindings/trusted_types.dart
+++ b/lib/bindings/trusted_types.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library trusted_types;
 

--- a/lib/bindings/ua_client_hints.dart
+++ b/lib/bindings/ua_client_hints.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library ua_client_hints;
 

--- a/lib/bindings/uievents.dart
+++ b/lib/bindings/uievents.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library uievents;
 

--- a/lib/bindings/url.dart
+++ b/lib/bindings/url.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library url;
 

--- a/lib/bindings/urlpattern.dart
+++ b/lib/bindings/urlpattern.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library urlpattern;
 

--- a/lib/bindings/user_timing.dart
+++ b/lib/bindings/user_timing.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library user_timing;
 

--- a/lib/bindings/vibration.dart
+++ b/lib/bindings/vibration.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library vibration;
 

--- a/lib/bindings/video_rvfc.dart
+++ b/lib/bindings/video_rvfc.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library video_rvfc;
 

--- a/lib/bindings/virtual_keyboard.dart
+++ b/lib/bindings/virtual_keyboard.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library virtual_keyboard;
 

--- a/lib/bindings/wai_aria_1_2.dart
+++ b/lib/bindings/wai_aria_1_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library wai_aria_1_2;
 

--- a/lib/bindings/wasm_js_api_2.dart
+++ b/lib/bindings/wasm_js_api_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library wasm_js_api_2;
 

--- a/lib/bindings/wasm_web_api_2.dart
+++ b/lib/bindings/wasm_web_api_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library wasm_web_api_2;
 

--- a/lib/bindings/web_animations_1.dart
+++ b/lib/bindings/web_animations_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library web_animations_1;
 

--- a/lib/bindings/web_animations_2.dart
+++ b/lib/bindings/web_animations_2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library web_animations_2;
 

--- a/lib/bindings/web_app_launch.dart
+++ b/lib/bindings/web_app_launch.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library web_app_launch;
 

--- a/lib/bindings/web_bluetooth.dart
+++ b/lib/bindings/web_bluetooth.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library web_bluetooth;
 

--- a/lib/bindings/web_locks.dart
+++ b/lib/bindings/web_locks.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library web_locks;
 

--- a/lib/bindings/web_nfc.dart
+++ b/lib/bindings/web_nfc.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library web_nfc;
 

--- a/lib/bindings/web_otp.dart
+++ b/lib/bindings/web_otp.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library web_otp;
 

--- a/lib/bindings/web_share.dart
+++ b/lib/bindings/web_share.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library web_share;
 

--- a/lib/bindings/webaudio.dart
+++ b/lib/bindings/webaudio.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webaudio;
 

--- a/lib/bindings/webauthn_3.dart
+++ b/lib/bindings/webauthn_3.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webauthn_3;
 

--- a/lib/bindings/webcodecs.dart
+++ b/lib/bindings/webcodecs.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webcodecs;
 

--- a/lib/bindings/webcodecs_aac_codec_registration.dart
+++ b/lib/bindings/webcodecs_aac_codec_registration.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webcodecs_aac_codec_registration;
 

--- a/lib/bindings/webcodecs_avc_codec_registration.dart
+++ b/lib/bindings/webcodecs_avc_codec_registration.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webcodecs_avc_codec_registration;
 

--- a/lib/bindings/webcodecs_flac_codec_registration.dart
+++ b/lib/bindings/webcodecs_flac_codec_registration.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webcodecs_flac_codec_registration;
 

--- a/lib/bindings/webcodecs_hevc_codec_registration.dart
+++ b/lib/bindings/webcodecs_hevc_codec_registration.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webcodecs_hevc_codec_registration;
 

--- a/lib/bindings/webcodecs_opus_codec_registration.dart
+++ b/lib/bindings/webcodecs_opus_codec_registration.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webcodecs_opus_codec_registration;
 

--- a/lib/bindings/webcrypto_secure_curves.dart
+++ b/lib/bindings/webcrypto_secure_curves.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webcrypto_secure_curves;
 

--- a/lib/bindings/webcryptoapi.dart
+++ b/lib/bindings/webcryptoapi.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webcryptoapi;
 

--- a/lib/bindings/webdriver2.dart
+++ b/lib/bindings/webdriver2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webdriver2;
 

--- a/lib/bindings/webgl1.dart
+++ b/lib/bindings/webgl1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl1;
 

--- a/lib/bindings/webgl2.dart
+++ b/lib/bindings/webgl2.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl2;
 

--- a/lib/bindings/webgl_blend_equation_advanced_coherent.dart
+++ b/lib/bindings/webgl_blend_equation_advanced_coherent.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_blend_equation_advanced_coherent;
 

--- a/lib/bindings/webgl_color_buffer_float.dart
+++ b/lib/bindings/webgl_color_buffer_float.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_color_buffer_float;
 

--- a/lib/bindings/webgl_compressed_texture_astc.dart
+++ b/lib/bindings/webgl_compressed_texture_astc.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_compressed_texture_astc;
 

--- a/lib/bindings/webgl_compressed_texture_etc.dart
+++ b/lib/bindings/webgl_compressed_texture_etc.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_compressed_texture_etc;
 

--- a/lib/bindings/webgl_compressed_texture_etc1.dart
+++ b/lib/bindings/webgl_compressed_texture_etc1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_compressed_texture_etc1;
 

--- a/lib/bindings/webgl_compressed_texture_pvrtc.dart
+++ b/lib/bindings/webgl_compressed_texture_pvrtc.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_compressed_texture_pvrtc;
 

--- a/lib/bindings/webgl_compressed_texture_s3tc.dart
+++ b/lib/bindings/webgl_compressed_texture_s3tc.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_compressed_texture_s3tc;
 

--- a/lib/bindings/webgl_compressed_texture_s3tc_srgb.dart
+++ b/lib/bindings/webgl_compressed_texture_s3tc_srgb.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_compressed_texture_s3tc_srgb;
 

--- a/lib/bindings/webgl_debug_renderer_info.dart
+++ b/lib/bindings/webgl_debug_renderer_info.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_debug_renderer_info;
 

--- a/lib/bindings/webgl_debug_shaders.dart
+++ b/lib/bindings/webgl_debug_shaders.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_debug_shaders;
 

--- a/lib/bindings/webgl_depth_texture.dart
+++ b/lib/bindings/webgl_depth_texture.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_depth_texture;
 

--- a/lib/bindings/webgl_draw_buffers.dart
+++ b/lib/bindings/webgl_draw_buffers.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_draw_buffers;
 

--- a/lib/bindings/webgl_draw_instanced_base_vertex_base_instance.dart
+++ b/lib/bindings/webgl_draw_instanced_base_vertex_base_instance.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_draw_instanced_base_vertex_base_instance;
 

--- a/lib/bindings/webgl_lose_context.dart
+++ b/lib/bindings/webgl_lose_context.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_lose_context;
 

--- a/lib/bindings/webgl_multi_draw.dart
+++ b/lib/bindings/webgl_multi_draw.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_multi_draw;
 

--- a/lib/bindings/webgl_multi_draw_instanced_base_vertex_base_instance.dart
+++ b/lib/bindings/webgl_multi_draw_instanced_base_vertex_base_instance.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgl_multi_draw_instanced_base_vertex_base_instance;
 

--- a/lib/bindings/webgpu.dart
+++ b/lib/bindings/webgpu.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webgpu;
 

--- a/lib/bindings/webhid.dart
+++ b/lib/bindings/webhid.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webhid;
 

--- a/lib/bindings/webidl.dart
+++ b/lib/bindings/webidl.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webidl;
 

--- a/lib/bindings/webmidi.dart
+++ b/lib/bindings/webmidi.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webmidi;
 

--- a/lib/bindings/webnn.dart
+++ b/lib/bindings/webnn.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webnn;
 

--- a/lib/bindings/webrtc.dart
+++ b/lib/bindings/webrtc.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webrtc;
 

--- a/lib/bindings/webrtc_encoded_transform.dart
+++ b/lib/bindings/webrtc_encoded_transform.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webrtc_encoded_transform;
 

--- a/lib/bindings/webrtc_ice.dart
+++ b/lib/bindings/webrtc_ice.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webrtc_ice;
 

--- a/lib/bindings/webrtc_identity.dart
+++ b/lib/bindings/webrtc_identity.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webrtc_identity;
 

--- a/lib/bindings/webrtc_priority.dart
+++ b/lib/bindings/webrtc_priority.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webrtc_priority;
 

--- a/lib/bindings/webrtc_stats.dart
+++ b/lib/bindings/webrtc_stats.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webrtc_stats;
 

--- a/lib/bindings/webrtc_svc.dart
+++ b/lib/bindings/webrtc_svc.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webrtc_svc;
 

--- a/lib/bindings/websockets.dart
+++ b/lib/bindings/websockets.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library websockets;
 

--- a/lib/bindings/webtransport.dart
+++ b/lib/bindings/webtransport.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webtransport;
 

--- a/lib/bindings/webusb.dart
+++ b/lib/bindings/webusb.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webusb;
 

--- a/lib/bindings/webvtt1.dart
+++ b/lib/bindings/webvtt1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webvtt1;
 

--- a/lib/bindings/webxr.dart
+++ b/lib/bindings/webxr.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webxr;
 

--- a/lib/bindings/webxr_ar_module_1.dart
+++ b/lib/bindings/webxr_ar_module_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webxr_ar_module_1;
 

--- a/lib/bindings/webxr_depth_sensing_1.dart
+++ b/lib/bindings/webxr_depth_sensing_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webxr_depth_sensing_1;
 

--- a/lib/bindings/webxr_dom_overlays_1.dart
+++ b/lib/bindings/webxr_dom_overlays_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webxr_dom_overlays_1;
 

--- a/lib/bindings/webxr_gamepads_module_1.dart
+++ b/lib/bindings/webxr_gamepads_module_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webxr_gamepads_module_1;
 

--- a/lib/bindings/webxr_hand_input_1.dart
+++ b/lib/bindings/webxr_hand_input_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webxr_hand_input_1;
 

--- a/lib/bindings/webxr_hit_test_1.dart
+++ b/lib/bindings/webxr_hit_test_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webxr_hit_test_1;
 

--- a/lib/bindings/webxr_lighting_estimation_1.dart
+++ b/lib/bindings/webxr_lighting_estimation_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webxr_lighting_estimation_1;
 

--- a/lib/bindings/webxrlayers_1.dart
+++ b/lib/bindings/webxrlayers_1.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library webxrlayers_1;
 

--- a/lib/bindings/window_controls_overlay.dart
+++ b/lib/bindings/window_controls_overlay.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library window_controls_overlay;
 

--- a/lib/bindings/window_placement.dart
+++ b/lib/bindings/window_placement.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library window_placement;
 

--- a/lib/bindings/xhr.dart
+++ b/lib/bindings/xhr.dart
@@ -4,7 +4,7 @@
 
 // ignore_for_file: unused_import
 
-@JS('window')
+@JS('self')
 @staticInterop
 library xhr;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: js_bindings
 description: Complete JS bindings interop with autocomplete and documentation.
-version: 0.0.9
+version: 0.0.10
 repository: https://github.com/jodinathan/js_bindings
 
 environment:

--- a/tool/package_js/build.dart
+++ b/tool/package_js/build.dart
@@ -655,7 +655,7 @@ Future<void> main() async {
       
       // ignore_for_file: unused_import
       
-      @JS('window')
+      @JS('self')
       @staticInterop
       library $libraryName;
 


### PR DESCRIPTION
The current bindings assume you're within a browser environment, and that `window` is available. However if you're within a [service worker](https://developer.mozilla.org/en-US/docs/Web/API/Service_Worker_API) API, `window` does not exist. 

Using `self` means bindings which are available within a service worker are accessible, but also it continues to work on the browser, since `window` is `self`.